### PR TITLE
Add time-to-goal conditioning for CFGRL

### DIFF
--- a/ogbench/utils/datasets.py
+++ b/ogbench/utils/datasets.py
@@ -241,12 +241,15 @@ class GCDataset:
             self.config['actor_geom_sample'],
         )
 
+        actor_offsets = actor_goal_idxs - idxs
+
         if 'oracle_reps' in self.dataset:
             batch['value_goals'] = self.dataset['oracle_reps'][value_goal_idxs]
             batch['actor_goals'] = self.dataset['oracle_reps'][actor_goal_idxs]
         else:
             batch['value_goals'] = self.get_observations(value_goal_idxs)
             batch['actor_goals'] = self.get_observations(actor_goal_idxs)
+        batch['actor_offsets'] = actor_offsets[:, None]
         successes = (idxs == value_goal_idxs).astype(float)
         batch['masks'] = 1.0 - successes
         batch['rewards'] = successes - (1.0 if self.config['gc_negative'] else 0.0)

--- a/ogbench/utils/networks.py
+++ b/ogbench/utils/networks.py
@@ -536,7 +536,7 @@ class GCActorVectorField(nn.Module):
         self.mlp = MLP((*self.hidden_dims, self.action_dim), activate_final=False, layer_norm=self.layer_norm)
 
     @nn.compact
-    def __call__(self, observations, actions, times, goals=None, is_encoded=False):
+    def __call__(self, observations, actions, times, goals=None, goal_steps=None, is_encoded=False):
         """Return the vectors at the given states, actions, and times, and goals (optional).
 
         Args:
@@ -548,10 +548,13 @@ class GCActorVectorField(nn.Module):
         """
         if self.encoder is not None and not is_encoded:
             observations = self.encoder(observations)
-        if goals is None:
-            inputs = jnp.concatenate([observations, actions, times], axis=-1)
-        else:
-            inputs = jnp.concatenate([observations, goals, actions, times], axis=-1)
+        inputs = [observations]
+        if goals is not None:
+            inputs.append(goals)
+        inputs.extend([actions, times])
+        if goal_steps is not None:
+            inputs.append(goal_steps)
+        inputs = jnp.concatenate(inputs, axis=-1)
         v = self.mlp(inputs)
         return v
 


### PR DESCRIPTION
## Summary
- extend `GCActorVectorField` to accept `goal_steps` conditioning
- modify `GCDataset.sample` to provide `actor_offsets`
- update CFGRL actor flow to combine unconditional, goal, and time-conditioned flows via new `cfg2`

## Testing
- `ruff check ogbench/utils/networks.py ogbench/utils/datasets.py ogbench/agents/cfgrl.py`
- `python -m py_compile ogbench/agents/cfgrl.py ogbench/utils/datasets.py ogbench/utils/networks.py`


------
https://chatgpt.com/codex/tasks/task_e_6849c9900ab88329af0f7a0b9931d922